### PR TITLE
Improve HDF5 validation when processing GEDI tiles

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,6 +56,9 @@ def read_h5_image(path: Path) -> np.ndarray:
     The file may contain multiple datasets, so the dataset with the greatest
     number of elements is selected without loading each candidate into memory.
     """
+    if not h5py.is_hdf5(path):
+        raise ValueError(f"{path} is not a valid HDF5 file")
+
     # Determine the largest 2-D or 3-D dataset path first
     with h5py.File(path, "r") as f:
         target_name = None


### PR DESCRIPTION
## Summary
- validate `.h5` files using `h5py.is_hdf5` before opening them
- raise a clearer error when an invalid GEDI file is encountered

## Testing
- `pytest -q`
- `python -m pip check`


------
https://chatgpt.com/codex/tasks/task_e_685f010c6d988327bb2e698fcfc654dd