### PR TITLE
Fix earthaccess login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,8 @@ cython_debug/
 
 # OpenAI & Model-related
 openai_api_key.txt
+username.txt
+password.txt
 *.pt
 *.ckpt
 *.onnx

--- a/gedi-downloaders/download_gedi_jutai.py
+++ b/gedi-downloaders/download_gedi_jutai.py
@@ -1,6 +1,15 @@
 import earthaccess
+from pathlib import Path
 
-earthaccess.login(strategy="browser")
+# Load Earthdata credentials from the repository root
+ROOT = Path(__file__).resolve().parent.parent
+username_path = ROOT / "username.txt"
+password_path = ROOT / "password.txt"
+username = username_path.read_text().strip() if username_path.exists() else ""
+password = password_path.read_text().strip() if password_path.exists() else ""
+
+# Authenticate using the stored credentials
+earthaccess.login(username=username, password=password)
 
 granules = earthaccess.search_data(
     short_name="GEDI02_A",

--- a/gedi-downloaders/download_gedi_serra.py
+++ b/gedi-downloaders/download_gedi_serra.py
@@ -1,6 +1,15 @@
 import earthaccess
+from pathlib import Path
 
-earthaccess.login(strategy="browser")
+# Load Earthdata credentials from the repository root
+ROOT = Path(__file__).resolve().parent.parent
+username_path = ROOT / "username.txt"
+password_path = ROOT / "password.txt"
+username = username_path.read_text().strip() if username_path.exists() else ""
+password = password_path.read_text().strip() if password_path.exists() else ""
+
+# Authenticate using the stored credentials
+earthaccess.login(username=username, password=password)
 
 granules = earthaccess.search_data(
     short_name="GEDI02_A",

--- a/gedi-downloaders/download_gedi_yanomami.py
+++ b/gedi-downloaders/download_gedi_yanomami.py
@@ -1,6 +1,15 @@
 import earthaccess
+from pathlib import Path
 
-earthaccess.login(strategy="browser")
+# Load Earthdata credentials from the repository root
+ROOT = Path(__file__).resolve().parent.parent
+username_path = ROOT / "username.txt"
+password_path = ROOT / "password.txt"
+username = username_path.read_text().strip() if username_path.exists() else ""
+password = password_path.read_text().strip() if password_path.exists() else ""
+
+# Authenticate using the stored credentials
+earthaccess.login(username=username, password=password)
 
 granules = earthaccess.search_data(
     short_name="GEDI02_A",


### PR DESCRIPTION
## Summary
- read NASA Earthdata credentials from `username.txt` and `password.txt`
- authenticate using these credentials in each GEDI download script
- ignore the credential files in git

## Testing
- `python -m py_compile gedi-downloaders/download_gedi_jutai.py gedi-downloaders/download_gedi_serra.py gedi-downloaders/download_gedi_yanomami.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6860182fd5008327a901953c12d2448d