### PR TITLE
Fix earthaccess login parameter order

### DIFF
--- a/gedi-downloaders/download_gedi_jutai.py
+++ b/gedi-downloaders/download_gedi_jutai.py
@@ -8,10 +8,11 @@ password_path = ROOT / "password.txt"
 username = username_path.read_text().strip() if username_path.exists() else ""
 password = password_path.read_text().strip() if password_path.exists() else ""
 
-# Authenticate using the stored credentials
-# ``earthaccess.login`` expects positional arguments for the username and
-# password rather than keyword arguments.
-earthaccess.login(username, password)
+# Authenticate using the stored credentials. ``earthaccess.login`` expects the
+# username and password to be provided as keyword arguments; passing them as
+# positional values can cause the library to treat the username as the login
+# strategy and fail to initialise the session.
+earthaccess.login(username=username, password=password)
 
 granules = earthaccess.search_data(
     short_name="GEDI02_A",

--- a/gedi-downloaders/download_gedi_serra.py
+++ b/gedi-downloaders/download_gedi_serra.py
@@ -8,10 +8,11 @@ password_path = ROOT / "password.txt"
 username = username_path.read_text().strip() if username_path.exists() else ""
 password = password_path.read_text().strip() if password_path.exists() else ""
 
-# Authenticate using the stored credentials
-# ``earthaccess.login`` expects positional arguments for the username and
-# password rather than keyword arguments.
-earthaccess.login(username, password)
+# Authenticate using the stored credentials. ``earthaccess.login`` expects the
+# username and password to be provided as keyword arguments; passing them as
+# positional values can cause the library to treat the username as the login
+# strategy and fail to initialise the session.
+earthaccess.login(username=username, password=password)
 
 granules = earthaccess.search_data(
     short_name="GEDI02_A",

--- a/gedi-downloaders/download_gedi_yanomami.py
+++ b/gedi-downloaders/download_gedi_yanomami.py
@@ -8,10 +8,11 @@ password_path = ROOT / "password.txt"
 username = username_path.read_text().strip() if username_path.exists() else ""
 password = password_path.read_text().strip() if password_path.exists() else ""
 
-# Authenticate using the stored credentials
-# ``earthaccess.login`` expects positional arguments for the username and
-# password rather than keyword arguments.
-earthaccess.login(username, password)
+# Authenticate using the stored credentials. ``earthaccess.login`` expects the
+# username and password to be provided as keyword arguments; passing them as
+# positional values can cause the library to treat the username as the login
+# strategy and fail to initialise the session.
+earthaccess.login(username=username, password=password)
 
 granules = earthaccess.search_data(
     short_name="GEDI02_A",


### PR DESCRIPTION
## Summary
- ensure earthaccess login uses keyword arguments across download scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68602f7d6070832785aa8cf0107d7a53