### PR TITLE
Fix earthaccess login compatibility

### DIFF
--- a/gedi-downloaders/download_gedi_jutai.py
+++ b/gedi-downloaders/download_gedi_jutai.py
@@ -8,11 +8,18 @@ password_path = ROOT / "password.txt"
 username = username_path.read_text().strip() if username_path.exists() else ""
 password = password_path.read_text().strip() if password_path.exists() else ""
 
-# Authenticate using the stored credentials. ``earthaccess.login`` expects the
-# username and password to be provided as keyword arguments; passing them as
-# positional values can cause the library to treat the username as the login
-# strategy and fail to initialise the session.
-earthaccess.login(username=username, password=password)
+# Authenticate using the stored credentials. Newer versions of
+# ``earthaccess`` accept ``username`` and ``password`` as keyword arguments
+# while older releases expect them as positional parameters.  Attempt the
+# keyword form first then fall back to the positional call for maximum
+# compatibility.
+try:
+    earthaccess.login(username=username, password=password)
+except TypeError as exc:
+    if "unexpected keyword argument" in str(exc):
+        earthaccess.login(username, password)
+    else:
+        raise
 
 granules = earthaccess.search_data(
     short_name="GEDI02_A",

--- a/gedi-downloaders/download_gedi_serra.py
+++ b/gedi-downloaders/download_gedi_serra.py
@@ -8,11 +8,18 @@ password_path = ROOT / "password.txt"
 username = username_path.read_text().strip() if username_path.exists() else ""
 password = password_path.read_text().strip() if password_path.exists() else ""
 
-# Authenticate using the stored credentials. ``earthaccess.login`` expects the
-# username and password to be provided as keyword arguments; passing them as
-# positional values can cause the library to treat the username as the login
-# strategy and fail to initialise the session.
-earthaccess.login(username=username, password=password)
+# Authenticate using the stored credentials. Newer versions of
+# ``earthaccess`` accept ``username`` and ``password`` as keyword arguments
+# while older releases expect them as positional parameters.  Attempt the
+# keyword form first then fall back to the positional call for maximum
+# compatibility.
+try:
+    earthaccess.login(username=username, password=password)
+except TypeError as exc:
+    if "unexpected keyword argument" in str(exc):
+        earthaccess.login(username, password)
+    else:
+        raise
 
 granules = earthaccess.search_data(
     short_name="GEDI02_A",

--- a/gedi-downloaders/download_gedi_yanomami.py
+++ b/gedi-downloaders/download_gedi_yanomami.py
@@ -8,11 +8,18 @@ password_path = ROOT / "password.txt"
 username = username_path.read_text().strip() if username_path.exists() else ""
 password = password_path.read_text().strip() if password_path.exists() else ""
 
-# Authenticate using the stored credentials. ``earthaccess.login`` expects the
-# username and password to be provided as keyword arguments; passing them as
-# positional values can cause the library to treat the username as the login
-# strategy and fail to initialise the session.
-earthaccess.login(username=username, password=password)
+# Authenticate using the stored credentials. Newer versions of
+# ``earthaccess`` accept ``username`` and ``password`` as keyword arguments
+# while older releases expect them as positional parameters.  Attempt the
+# keyword form first then fall back to the positional call for maximum
+# compatibility.
+try:
+    earthaccess.login(username=username, password=password)
+except TypeError as exc:
+    if "unexpected keyword argument" in str(exc):
+        earthaccess.login(username, password)
+    else:
+        raise
 
 granules = earthaccess.search_data(
     short_name="GEDI02_A",


### PR DESCRIPTION
## Summary
- handle older earthaccess versions in download scripts

## Testing
- `python -m py_compile gedi-downloaders/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6860339d757883279aa238c37e271d2f