### PR TITLE
Fix GEDI download path and login

### DIFF
--- a/gedi-downloaders/download_gedi_jutai.py
+++ b/gedi-downloaders/download_gedi_jutai.py
@@ -1,10 +1,9 @@
 """Download GEDI granules for the Rio Jutai headwaters."""
 
-from pathlib import Path
 import utils
 
 BBOX = (-68.5, -6.0, -68.5, -4.5)  # Rio Jutai Headwaters
-TARGET = Path("./data/raw/riojutai")
+TARGET = utils.data_path("riojutai")
 
 
 def main() -> None:

--- a/gedi-downloaders/download_gedi_serra.py
+++ b/gedi-downloaders/download_gedi_serra.py
@@ -1,10 +1,9 @@
 """Download GEDI granules for the Serra do Divisor region."""
 
-from pathlib import Path
 import utils
 
 BBOX = (-74.0, -8.0, -72.5, -6.0)  # Serra do Divisor
-TARGET = Path("./data/raw/serra")
+TARGET = utils.data_path("serra")
 
 
 def main() -> None:

--- a/gedi-downloaders/download_gedi_yanomami.py
+++ b/gedi-downloaders/download_gedi_yanomami.py
@@ -1,10 +1,9 @@
 """Download GEDI granules for the Yanomami frontier."""
 
-from pathlib import Path
 import utils
 
 BBOX = (-65.0, 1.0, -62.0, 4.0)  # Yanomami Frontier
-TARGET = Path("./data/raw/yanomami")
+TARGET = utils.data_path("yanomami")
 
 
 def main() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ transformers
 earthengine-api
 boto3
 h5py
+earthaccess
 numpy
 matplotlib
 scipy


### PR DESCRIPTION
## Summary
- ensure GEDI data is stored under `data/raw`
- handle Earthdata credentials more robustly
- add `earthaccess` to requirements

## Testing
- `python -m py_compile gedi-downloaders/utils.py gedi-downloaders/download_gedi_jutai.py gedi-downloaders/download_gedi_serra.py gedi-downloaders/download_gedi_yanomami.py`

------
https://chatgpt.com/codex/tasks/task_e_68603e5bfa048327b17d3e6f28afaf80