### PR TITLE
Rasterize GEDI h5 tiles to 2D grids

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Pillow
 scikit-image
 openai
 tqdm
+scipy


### PR DESCRIPTION
## Summary
- convert GEDI point clouds to spatial grids before imaging
- include scipy requirement

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6860aa18964c832780398a103e05a410