### PR TITLE
Limit GEDI downloads to 200 granules

### DIFF
--- a/gedi-downloaders/download_gedi_jutai.py
+++ b/gedi-downloaders/download_gedi_jutai.py
@@ -6,11 +6,14 @@ BBOX = (-68.5, -6.0, -68.5, -4.5)  # Rio Jutai Headwaters
 TARGET = utils.data_path("riojutai")
 
 
+LIMIT = 200
+
+
 def main() -> None:
     utils.login()
     granules = utils.search("GEDI02_A", BBOX)
     print(f"Found {len(granules)} GEDI granules in Rio Jutai headwaters")
-    utils.download(granules, TARGET)
+    utils.download(granules, TARGET, limit=LIMIT)
 
 
 if __name__ == "__main__":

--- a/gedi-downloaders/download_gedi_serra.py
+++ b/gedi-downloaders/download_gedi_serra.py
@@ -6,11 +6,14 @@ BBOX = (-74.0, -8.0, -72.5, -6.0)  # Serra do Divisor
 TARGET = utils.data_path("serra")
 
 
+LIMIT = 200
+
+
 def main() -> None:
     utils.login()
     granules = utils.search("GEDI02_A", BBOX)
     print(f"Found {len(granules)} GEDI granules in Serra do Divisor")
-    utils.download(granules, TARGET)
+    utils.download(granules, TARGET, limit=LIMIT)
 
 
 if __name__ == "__main__":

--- a/gedi-downloaders/download_gedi_yanomami.py
+++ b/gedi-downloaders/download_gedi_yanomami.py
@@ -6,11 +6,14 @@ BBOX = (-65.0, 1.0, -62.0, 4.0)  # Yanomami Frontier
 TARGET = utils.data_path("yanomami")
 
 
+LIMIT = 200
+
+
 def main() -> None:
     utils.login()
     granules = utils.search("GEDI02_A", BBOX)
     print(f"Found {len(granules)} GEDI granules in Yanomami frontier")
-    utils.download(granules, TARGET)
+    utils.download(granules, TARGET, limit=LIMIT)
 
 
 if __name__ == "__main__":

--- a/gedi-downloaders/utils.py
+++ b/gedi-downloaders/utils.py
@@ -47,8 +47,16 @@ def search(short_name: str, bbox: tuple[float, float, float, float]):
     )
 
 
-def download(granules, target: str | Path) -> None:
+from itertools import islice
+
+
+def download(granules, target: str | Path, limit: int | None = None) -> None:
+    """Download ``granules`` into ``target`` with an optional limit."""
     target_path = Path(target)
     target_path.mkdir(parents=True, exist_ok=True)
+
+    if limit is not None:
+        granules = list(islice(granules, limit))
+
     earthaccess.download(granules, str(target_path))
 


### PR DESCRIPTION
## Summary
- cap GEDI granule downloads with a `limit` parameter
- restrict each download script to 200 files

## Testing
- `python -m py_compile gedi-downloaders/utils.py gedi-downloaders/download_gedi_jutai.py gedi-downloaders/download_gedi_serra.py gedi-downloaders/download_gedi_yanomami.py`

------
https://chatgpt.com/codex/tasks/task_e_68629598e56c8327a8218f5a10160d0d